### PR TITLE
Yet another fix for the status check name in eclipse-lyo.jsonnet

### DIFF
--- a/otterdog/eclipse-lyo.jsonnet
+++ b/otterdog/eclipse-lyo.jsonnet
@@ -425,7 +425,7 @@ orgs.newOrg('technology.lyo', 'eclipse-lyo') {
           required_status_checks+: {
             strict: true,
             status_checks+: [
-              "Test Suite [OSLC Core 2.0 / CM] / build (21) (pull_request)"
+              "Test Suite [OSLC Core 2.0 / CM] / build (21)"
             ],
           },
           required_merge_queue: orgs.newMergeQueue() {


### PR DESCRIPTION
Hopefully, this is the correct name of the check and it will be enough to unblock the merge queue.