### PR TITLE
build: yet another check rename + project lead bypass

### DIFF
--- a/otterdog/eclipse-lyo.jsonnet
+++ b/otterdog/eclipse-lyo.jsonnet
@@ -419,13 +419,17 @@ orgs.newOrg('technology.lyo', 'eclipse-lyo') {
           include_refs+: [
             "~DEFAULT_BRANCH"
           ],
+          bypass_actors+: [
+            "@eclipse-lyo/technology-lyo-project-leads",
+          ],
+          allows_creations: true,
           required_pull_request+: {
             required_approving_review_count: 0,
           },
           required_status_checks+: {
             strict: true,
             status_checks+: [
-              "Test Suite [OSLC Core 2.0 / CM] / build (21)"
+              "build (21)"
             ],
           },
           required_merge_queue: orgs.newMergeQueue() {


### PR DESCRIPTION
Yet another rename for the check. This is quite frustrating, seems like I cannot figure out the right check name for a one of the matrix build checks. This time I use the `gh` CLI tool to get the ids reported there programmatically. Seems like `build (21)` is what's used, not sure it's going to be accepted correctly by GH when applied via otterdog.

Also allowing bypass for project leads.